### PR TITLE
Se configuro redux immutable state invariant

### DIFF
--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -5,10 +5,12 @@
 import {createStore, compose, applyMiddleware} from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import rootReducer from '../reducers';
+import reduxImmutableStateInvariant from 'redux-immutable-state-invariant';
 
 export default function configureStore(initialState) {
   const middewares = [
     // Add other middleware on this line...
+    reduxImmutableStateInvariant(),
 
     // thunk middleware can also accept an extra argument to be passed to each thunk action
     // https://github.com/gaearon/redux-thunk#injecting-a-custom-argument


### PR DESCRIPTION
Sirve para controlar que el estado siempre se mantenga inmutable.

En la ejecuccion de la aplicacion web, cuando se cambie el state de forma mutable se desplegara un error en la consola web advirtiendo de este cambio.
