### PR TITLE
se separo los input de nombre y apellido

### DIFF
--- a/src/api/adopterApi.js
+++ b/src/api/adopterApi.js
@@ -32,11 +32,8 @@ export default AdopterApi;
 
 export const parseAdopter = (adopter) => {
   let parsedAdopter = {};
-  let splitFullName = _.words(adopter.fullName);
-  adopter.firstName = splitFullName[0];
-  adopter.lastName = splitFullName[1];
   for (let prop in adopter) {
-    if (adopter[prop] !== '' && prop !== 'fullName') {
+    if (adopter[prop] !== '') {
       let snakeProp = _.snakeCase(prop);
       if (prop === 'ci') {
         parsedAdopter[snakeProp] = _.replace(adopter[prop], '-', '');

--- a/src/components/adopters/AdopterForm.js
+++ b/src/components/adopters/AdopterForm.js
@@ -5,19 +5,25 @@ import ModalAnimalButtons from '../common/ModalAnimalButtons';
 
 const AdopterForm = ({ adopter, onSave, onChange, onCancel, errors }) => {
 
-  const errorsFullName = errors.firstName || errors.lastName;
-
   return (
     <div className="form-container">
       <p> * campos necesarios </p>
       <div className="animal-form">
         <Input styleClass="animal-input"
-                name="fullName"
-                label="Nombre y Apellido *"
+                name="firstName"
+                label="Nombre *"
                 type="text"
-                value={adopter.fullName}
+                value={adopter.firstName}
                 onChange={onChange}
-                error={errorsFullName}
+                error={errors.firstName}
+                 />
+        <Input styleClass="animal-input"
+                name="lastName"
+                label="Apellido *"
+                type="text"
+                value={adopter.lastName}
+                onChange={onChange}
+                error={errors.lastName}
                  />
         <Input styleClass="animal-input"
                 name="ci"

--- a/src/containers/modal/AddAdopterModal.js
+++ b/src/containers/modal/AddAdopterModal.js
@@ -17,7 +17,8 @@ class AddAdopterModal extends Component {
 
     this.state = {
       adopter: {
-        fullName: '',
+        firstName: '',
+        lastName: '',
         ci: '',
         email: '',
         phone: '',
@@ -36,7 +37,8 @@ class AddAdopterModal extends Component {
         blacklisted: ''
       },
       requiredFields: {
-        fullName: true,
+        firstName: true,
+        lastName: true,
         ci: true,
         email: false,
         phone: true,
@@ -66,18 +68,11 @@ class AddAdopterModal extends Component {
     let { errors, requiredFields } = this.state;
     for (let name in adopter) {
       if (requiredFields[name]) {
-        if (name === 'fullName') {
-          errors.firstName = valid.validateEmptyField(adopter.fullName);
-        } else {
-          errors[name] = valid.validateEmptyField(adopter[name]);
-        }
+        errors[name] = valid.validateEmptyField(adopter[name]);
       }
     }
     if (!errors.ci) {
       errors.ci = valid.validateCi(adopter.ci);
-    }
-    if (!errors.firstName && !errors.lastName) {
-      errors.firstName = valid.validateFullName(adopter.fullName);
     }
     if (!errors.phone) {
       errors.phone = valid.validatePhone(adopter.phone);
@@ -103,11 +98,7 @@ class AddAdopterModal extends Component {
     adopter[ name ] = value;
     this.setState({ adopter });
     if (this.state.requiredFields[ name ]) {
-      if (name === 'fullName') {
-        errors.firstName = valid.validateEmptyField(value);
-      } else {
-        errors[name] = valid.validateEmptyField(value);
-      }
+      errors[name] = valid.validateEmptyField(value);
       this.setState({ errors: errors });
     }
   }


### PR DESCRIPTION
Se separan los input para poder aceptar nombres compuestos y apellidos compuestos

BUG: https://trello.com/c/8Vt0SUfg/208-si-un-adoptante-tiene-un-nombre-compuesto-no-deja-poner-mas-de-dos-palabras-en-el-campo-de-nombre-y-apellido-por-lo-que-salta-er