### PR TITLE
se corrigio el texto del filtro estado

### DIFF
--- a/src/components/animals/AnimalFilters.js
+++ b/src/components/animals/AnimalFilters.js
@@ -122,7 +122,7 @@ class AnimalFilters extends Component {
     const boolean = [ { id: true, name: "SI" },
                     { id: false, name: "NO" } ];
     const states = [ { id: true, name: "ADOPTADO" },
-                    { id: false, name: "EN ADOPCIÓN" } ];
+                    { id: false, name: "NO ADOPTADO" } ];
     const sex = [ { id: 0, name: "MACHO" },
                     { id: 1, name: "HEMBRA" } ];
     let smallWindows = (windowWidth <= 541);


### PR DESCRIPTION
Cuando se seleccionaba el filtro estado en "EN ADOPCION" se retornaban los animales que estaban en adopcion y no disponibles, para que sea mas consistente con lo que se devuelve se cambio el texto de la opcion por "NO ADOPTADO"